### PR TITLE
テキスト選択を解除せずに続けて別のテキストを選択しても，翻訳できるように改良

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,18 +1,25 @@
-function check_deepl() {
+const sleep = (time) => new Promise(resolve => setTimeout(resolve, time));
+
+async function check_deepl() {
   //const translated_text = document.getElementsByClassName("lmt__textarea lmt__target_textarea lmt__textarea_base_style")[0];
   //return translated_text.value;
-  let target = document.getElementsByClassName(
-    "lmt__textarea lmt__target_textarea lmt__textarea_base_style"
-  )[0];
-
-  if (!target) {
-    setTimeout(check_deepl, 1000);
-  } else {
-    if (target.value == "") {
-      setTimeout(check_deepl, 1000);
-    } else {
+  const start_time = new Date();
+  while (true) {
+    const target = document.getElementsByClassName(
+      "lmt__textarea lmt__target_textarea lmt__textarea_base_style"
+    )[0];
+    if (target && target.value.length > 0) {
       return target.value;
     }
+
+    const current_time = new Date();
+    const diff = current_time.getTime() - start_time.getTime();
+    const diffSecond = Math.floor(diff / 1000);
+    if (diffSecond >= 7) {
+      return "";
+    }
+
+    await sleep(1000);
   }
   /*
   var observer = new MutationObserver(function (mutations) {
@@ -30,8 +37,7 @@ function check_deepl() {
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.type == "check_deepl") {
-    var translatedtext = check_deepl();
-    sendResponse(translatedtext);
+    check_deepl().then(sendResponse);
   }
   return true;
 });

--- a/content.js
+++ b/content.js
@@ -41,3 +41,5 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   }
   return true;
 });
+
+chrome.runtime.sendMessage({ type: 'ready' });

--- a/inject.js
+++ b/inject.js
@@ -3,68 +3,34 @@ const haifun = RegExp("([a-zA-Z])(-)([a-zA-Z])", "g");
 const koron = RegExp(":", "g");
 const semikoron = RegExp(";", "g");
 
-function removePanel(clickEvent) {
-  const e = document.querySelector("div.text-panel");
-  try {
-    const eRect = e.getBoundingClientRect();
-    if (
-      eRect.left <= clickEvent.pageX &&
-      clickEvent.pageX <=
-        eRect.left + parseInt(window.getComputedStyle(e).width) &&
-      eRect.top <= clickEvent.pageY &&
-      clickEvent.pageY <=
-        eRect.top + parseInt(window.getComputedStyle(e).height)
-    ) {
-      return;
-    }
-  } catch (e) {
+function removePanel(mouseEvent) {
+  const panel = document.querySelector("div.text-panel, div.text-panel-under");
+  if (panel === null || mouseEvent.path.includes(panel)) {
     return;
   }
-  document.querySelector("div.text-panel").remove();
-  document.addEventListener("click", translation);
+  panel.remove();
 }
 
-function removePanelUnder(clickEvent) {
-  const e = document.querySelector("div.text-panel-under");
-  try {
-    const eRect = e.getBoundingClientRect();
-    if (
-      eRect.left <= clickEvent.pageX &&
-      clickEvent.pageX <=
-        eRect.left + parseInt(window.getComputedStyle(e).width) &&
-      eRect.top <= clickEvent.pageY &&
-      clickEvent.pageY <=
-        eRect.top + parseInt(window.getComputedStyle(e).height)
-    ) {
-      return;
-    }
-  } catch (e) {
-    return;
-  }
-  document.querySelector("div.text-panel-under").remove();
-  document.addEventListener("click", translation);
-}
-
-function showPanel(text, clickEvent) {
+function showPanel(text, mouseEvent) {
   const extra = 20;
-  let panel = document.createElement("div");
+  const panel = document.createElement("div");
   panel.setAttribute("class", "text-panel");
   panel.setAttribute("contenteditable", true);
   const row = text.length / 32;
   let top;
   let left;
   if (row >= 2) {
-    if (clickEvent.pageY + row * 27 >= window.innerHeight) {
+    if (mouseEvent.pageY + row * 27 >= window.innerHeight) {
       top = window.innerHeight - row * 27 - extra;
     } else {
-      top = clickEvent.pageY;
+      top = mouseEvent.pageY;
     }
 
-    if (clickEvent.pageX + 550 >= window.innerWidth) {
+    if (mouseEvent.pageX + 550 >= window.innerWidth) {
       left =
-        clickEvent.pageX - (clickEvent.pageX + 550 - window.innerWidth) - extra;
+        mouseEvent.pageX - (mouseEvent.pageX + 550 - window.innerWidth) - extra;
     } else {
-      left = clickEvent.pageX;
+      left = mouseEvent.pageX;
     }
     if (top <= 42) {
       top = 42;
@@ -79,10 +45,10 @@ function showPanel(text, clickEvent) {
   } else {
     panel.setAttribute(
       "style",
-      "top:" + clickEvent.pageY + "px;left:" + clickEvent.pageX + "px;"
+      "top:" + mouseEvent.pageY + "px;left:" + mouseEvent.pageX + "px;"
     );
   }
-  panel.innerHTML = text;
+  panel.innerText = text;
   document.firstElementChild.appendChild(panel);
 }
 
@@ -94,7 +60,11 @@ function showPanelUnder(text) {
   document.firstElementChild.appendChild(panel);
 }
 
-function translation(clickEvent) {
+function translation(mouseEvent) {
+  const panel = document.querySelector("div.text-panel, div.text-panel-under");
+  if (panel !== null && mouseEvent.path.includes(panel)) {
+    return;
+  }
   const text = document.getSelection().toString();
   let target_text;
   if (text.length <= 1) {
@@ -107,12 +77,11 @@ function translation(clickEvent) {
         panel_pos = "near";
       }
       if (panel_pos == "near") {
-        showPanel("Too Long.", clickEvent);
+        showPanel("Too Long.", mouseEvent);
       } else {
         showPanelUnder("Too Long.");
       }
     });
-    document.removeEventListener("click", translation);
     return;
   }
   target_text = text.replace(/\r?\n/g, "");
@@ -144,12 +113,10 @@ function translation(clickEvent) {
             panel_pos = "near";
           }
           if (panel_pos == "near") {
-            showPanel(response.text, clickEvent);
+            showPanel(response.text, mouseEvent);
           } else {
             showPanelUnder(response.text);
           }
-          document.removeEventListener("click", translation);
-          return;
         });
       }
     );
@@ -177,6 +144,5 @@ function translation(clickEvent) {
     */
   return;
 }
-document.addEventListener("click", translation);
-document.addEventListener("click", removePanel);
-document.addEventListener("click", removePanelUnder);
+document.addEventListener("mouseup", translation);
+document.addEventListener("mousedown", removePanel);


### PR DESCRIPTION
Closes #24
あるテキストを翻訳後に別のテキストを翻訳する場合，一旦適当な場所をクリックしてテキスト選択を解除する必要がありました。このPRでは，その必要がなくなるような改良を施しています。
また，エラー `Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist.` を解消しました。