### PR TITLE
add key combination option

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -60,7 +60,30 @@ function showPanelUnder(text) {
   document.firstElementChild.appendChild(panel);
 }
 
-function translation(mouseEvent) {
+function getCombinaitonOption() {
+  return new Promise( (resolve) => {
+    chrome.storage.sync.get("combination", (item) => {
+        resolve(item["combination"]);
+    });
+    
+  });
+}
+
+async function translation(mouseEvent) {
+  let combination = await getCombinaitonOption();
+  if (combination === "ctrl") {
+    if (!mouseEvent.ctrlKey) return;
+  } 
+  else if (combination === "alt") {
+    if (!mouseEvent.altKey) return;
+  } 
+  else if (combination === "command") {
+    if (!mouseEvent.metaKey) return;
+  }
+  else if (combination === "shift") {
+    if (!mouseEvent.shiftKey) return;
+  }
+
   const panel = document.querySelector("div.text-panel, div.text-panel-under");
   if (panel !== null && mouseEvent.path.includes(panel)) {
     return;

--- a/option.html
+++ b/option.html
@@ -46,6 +46,16 @@
       <option value="under">under</option>
     </select>
 <br>
+<br>
+    <p>combination</p>
+    <select id="combination">
+      <option value="empty">(empty)</option>
+      <option value="ctrl">ctrl</option>
+      <option value="command">command</option>
+      <option value="alt">alt</option>
+      <option value="shift">shift</option>
+    </select>
+<br>
 <p>
   　<button id="save">保存</button>
 </p>

--- a/option.js
+++ b/option.js
@@ -5,12 +5,14 @@ function save_options() {
   var source_lang = document.getElementById("s_lang").value;
   var target_lang = document.getElementById("t_lang").value;
   var panel_pos = document.getElementById("panel_pos").value;
+  var combination = document.getElementById("combination").value;
 
   // chromeアカウントと紐づくストレージに保存
   chrome.storage.sync.set({
     source_language: source_lang,
     target_language: target_lang,
-    panel_pos: panel_pos
+    panel_pos: panel_pos,
+    combination: combination
   }, function() {
     // 保存できたら、画面にメッセージを表示(0.75秒だけ)
     var status = document.getElementById("status");
@@ -27,13 +29,14 @@ function restore_options() {
   chrome.storage.sync.get({
     source_language: "en",
     target_language: "ja",
-    panel_pos : "near"
-
+    panel_pos : "near",
+    combination: "empty"
   // 保存された値があったら、それを使う
   }, function(items) {
     document.getElementById("s_lang").value = items.source_language;
     document.getElementById("t_lang").value = items.target_language;
     document.getElementById("panel_pos").value = items.panel_pos;
+    document.getElementById("combination").value = items.combination;
   });
 }
 


### PR DESCRIPTION
キーコンビネーションにより、テキスト選択で翻訳するかしないかを選ぶことができるようにしてみました。
デフォルトはキーコンビネーションはなしにしており、オプションから"ctrl", "command", "alt", "shift"の中から同時押しに使うキーを選択できます。テキストを選択して、選択したキーを押しながらマウスを離した時のみ翻訳が実行されます。