### PR TITLE
update url redirect for open in new tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -68,7 +68,7 @@ chrome.webRequest.onHeadersReceived.addListener(
           return getHeadersWithContentDispositionAttachment(details);
         }
         let url = details.url;
-        chrome.tabs.update({
+        chrome.tabs.update(details.tabId, {
           url: chrome.runtime.getURL(
             `/pdf.js/web/viewer.html?file=${encodeURIComponent(url)}`
           ),


### PR DESCRIPTION
現在新しいタブでpdfを開くと、元のタブでPDF-Translatorが開き、新しいタブではchromeデフォルトのPDFリーダーでpdfが開くという状態でした。今回新しいタブでpdfを開いた際には、新しいタブでPDF-Translatorが開くようにしてみました。

あえて現在の仕様にしていたら申し訳ないのですが、もしかしたら期待通りの挙動ではないのではないかと思いPR送ってみました。気に入っていただけたら幸いです。

（変更後の新規タブで開く様子)
![ 2021-05-10 18 48 17](https://user-images.githubusercontent.com/44169535/117642312-18a26600-b1c2-11eb-91bc-fcce5e334fd5.gif)
