### PR TITLE
Chromeの更新に伴うEvent.path()の廃止への対応

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -5,7 +5,7 @@ const semicoron = RegExp(';', 'g');
 
 function removePanel(mouseEvent) {
   const panel = document.querySelector('div.text-panel, div.text-panel-under');
-  if (panel === null || mouseEvent.path.includes(panel)) {
+  if (panel === null || mouseEvent.composedPath().includes(panel)) {
     return;
   }
   panel.remove();
@@ -101,7 +101,7 @@ async function translation(mouseEvent) {
   }
 
   const panel = document.querySelector('div.text-panel, div.text-panel-under');
-  if (panel !== null && mouseEvent.path.includes(panel)) {
+  if (panel !== null && mouseEvent.composedPath().includes(panel)) {
     return;
   }
   const text = document.getSelection().toString();


### PR DESCRIPTION
# 変更内容
翻訳後の文章が表示されるパネルが消えない不具合を修正しました。

Chromeのバージョン109への更新に含まれる「Event.path()の廃止」が原因で、`mouseEvent.path()`が機能しなくなっていたので、`Event.composedPath()` を使用するように変更しました。

Referance: https://support.google.com/chrome/a/answer/7679408#evPathNo109
